### PR TITLE
fix: Add network_project_id to support shared VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ module "bigquery_loader_pubsub" {
 | <a name="input_name"></a> [name](#input\_name) | A name which will be pre-pended to the resources created | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | The name of the network to deploy within | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID in which the stack is being deployed | `string` | n/a | yes |
-| <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | The project ID of the shared VPC in which the stack is being deployed | `string` | n/a | yes |
+| <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | The project ID of the shared VPC in which the stack is being deployed | `string` | `""` | no |
 | <a name="input_region"></a> [region](#input\_region) | The name of the region to deploy within | `string` | n/a | yes |
 | <a name="input_accept_limited_use_license"></a> [accept\_limited\_use\_license](#input\_accept\_limited\_use\_license) | Acceptance of the SLULA terms (https://docs.snowplow.io/limited-use-license-1.0/) | `bool` | `false` | no |
 | <a name="input_app_version"></a> [app\_version](#input\_app\_version) | App version to use. This variable facilitates dev flow, the modules may not work with anything other than the default value. | `string` | `"1.7.0"` | no |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ module "bigquery_loader_pubsub" {
 | <a name="input_name"></a> [name](#input\_name) | A name which will be pre-pended to the resources created | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | The name of the network to deploy within | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID in which the stack is being deployed | `string` | n/a | yes |
+| <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | The project ID of the shared VPC in which the stack is being deployed | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The name of the region to deploy within | `string` | n/a | yes |
 | <a name="input_accept_limited_use_license"></a> [accept\_limited\_use\_license](#input\_accept\_limited\_use\_license) | Acceptance of the SLULA terms (https://docs.snowplow.io/limited-use-license-1.0/) | `bool` | `false` | no |
 | <a name="input_app_version"></a> [app\_version](#input\_app\_version) | App version to use. This variable facilitates dev flow, the modules may not work with anything other than the default value. | `string` | `"1.7.0"` | no |

--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,8 @@ resource "google_bigquery_dataset_iam_member" "dataset_bigquery_data_editor_bind
 # --- CE: Firewall rules
 
 resource "google_compute_firewall" "ingress_ssh" {
-  name = "${var.name}-ssh-in"
+  project = (var.network_project_id != "") ? var.network_project_id : var.project_id
+  name    = "${var.name}-ssh-in"
 
   network     = var.network
   target_tags = [var.name]
@@ -113,7 +114,8 @@ resource "google_compute_firewall" "ingress_ssh" {
 }
 
 resource "google_compute_firewall" "egress" {
-  name = "${var.name}-traffic-out"
+  project = (var.network_project_id != "") ? var.network_project_id : var.project_id
+  name    = "${var.name}-traffic-out"
 
   network     = var.network
   target_tags = [var.name]

--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,12 @@ variable "project_id" {
   type        = string
 }
 
+variable "network_project_id" {
+  description = "The project ID of the shared VPC in which the stack is being deployed"
+  type        = string
+  default     = ""
+}
+
 variable "region" {
   description = "The name of the region to deploy within"
   type        = string


### PR DESCRIPTION
# Background

Google has [Shared VPC](https://cloud.google.com/vpc/docs/shared-vpc) network topology. If we'd like to apply to a shared VPC, the current module will fail when trying to create firewall rules.

# Proposed solution

Add `network_project_id` variable as optional and allow backward compatible in case ppl using this module with `~>` in the source `version`.

## Added
- [x] `network_project_id` variable to support a shared VPC setup

## Changed
- [x] Update `README.md`
